### PR TITLE
Remove SSDT-XOSI. This can help get your I2C trackpad working properly

### DIFF
--- a/content/0.guide/2.gathering-files/3.acpi.md
+++ b/content/0.guide/2.gathering-files/3.acpi.md
@@ -110,9 +110,6 @@ AMD laptops should choose, in addition
 ::list{type="primary"}
 - `FakeEC Laptop`
 - `PNLF`
-- `XOSI`
-
-  Choose default (`A` key)
 ::
 
 Here's how the `Results` folder would look like after we're done

--- a/content/0.guide/2.gathering-files/3.acpi.md
+++ b/content/0.guide/2.gathering-files/3.acpi.md
@@ -110,6 +110,9 @@ AMD laptops should choose, in addition
 ::list{type="primary"}
 - `FakeEC Laptop`
 - `PNLF`
+- `XOSI`
+
+Choose default (`A` key). If you're having trouble with your trackpad's I2C connection, one potential solution is to remove SSDT-XOSI. This can help get things working properly again. Good luck!
 ::
 
 Here's how the `Results` folder would look like after we're done


### PR DESCRIPTION
Could you please double-check this issue and update the guide accordingly?